### PR TITLE
Remove some order-by calls reducing wall clock time.

### DIFF
--- a/src/witan/population/england.clj
+++ b/src/witan/population/england.clj
@@ -117,9 +117,7 @@
                             mye-f))]
     (-> (concat-mye-snpp mye-ds
                          snpp-ds
-                         (assoc options :min-snpp-year min-snpp-year))
-        ;; Sort only at the end
-        (tc/order-by [:ctyua23cd :year :age]))))
+                         (assoc options :min-snpp-year min-snpp-year)))))
 
 (comment ;; Example: CTYUA level for Surrey 10 year olds from 2020 to 2025 from default MYE & 2022 based SNPPs with default min-snpp-year
   (-> {:ctyuanm-f #{"Surrey"}

--- a/src/witan/population/england.clj
+++ b/src/witan/population/england.clj
@@ -50,14 +50,12 @@
         snpp-ds (-> options
                     (merge {})
                     snpp-2022/->dataset-by-lad)]
-    {:mye-ds    (-> mye-ds
-                    (#(tc/order-by % (tc/column-names %))))
-     :snpp-ds   (-> snpp-ds
-                    (#(tc/order-by % (tc/column-names %))))
-     :concat-ds (-> (concat-mye-snpp mye-ds
+    (-> {:mye-ds    mye-ds
+         :snpp-ds   snpp-ds
+         :concat-ds (concat-mye-snpp mye-ds
                                      snpp-ds
-                                     options)
-                    (#(tc/order-by % (tc/column-names %))))})
+                                     options)}
+        (update-vals #(tc/order-by % (tc/column-names %)))))
   ;;=> {:mye-ds [myebtablesenglandwales/myebtablesenglandwales20112024.xlsx]MYEB1: long by LAD (persons) [5 9]:
   ;;   
   ;;   |  :lad23cd |   :lad23nm | :ctyua23cd | :ctyua23nm | :country | :year | :age |    :sex | :population |
@@ -88,7 +86,7 @@
   ;;   | E06000005 | Darlington |  E06000005 | Darlington |  2024 |   10 | persons |    1276.514 |
   ;;   | E06000005 | Darlington |  E06000005 | Darlington |  2025 |   10 | persons |    1253.260 |
   ;;   }
-
+  
   :rcf)
 
 (defn ->dataset
@@ -125,7 +123,8 @@
        :max-age   10
        :min-year  2020
        :max-year  2025}
-      ->dataset)
+      ->dataset
+      (#(tc/order-by % (tc/column-names %))))
   ;;=> [myebtablesenglandwales/myebtablesenglandwales20112024.xlsx]MYEB1: long by CTYUA (persons) and 2022snpppopulationsyoa/2022snpppopulationsyoamigcat23/2022 SNPP Population persons.csv: long by CTYUA concatenated at min-snpp-year of 2022 [6 6]:
   ;;   
   ;;   | :ctyua23cd | :ctyua23nm | :year | :age |    :sex | :population |

--- a/src/witan/population/england.clj
+++ b/src/witan/population/england.clj
@@ -50,11 +50,14 @@
         snpp-ds (-> options
                     (merge {})
                     snpp-2022/->dataset-by-lad)]
-    {:mye-ds    mye-ds
-     :snpp-ds   snpp-ds
-     :concat-ds (concat-mye-snpp mye-ds
-                                 snpp-ds
-                                 options)})
+    {:mye-ds    (-> mye-ds
+                    (#(tc/order-by % (tc/column-names %))))
+     :snpp-ds   (-> snpp-ds
+                    (#(tc/order-by % (tc/column-names %))))
+     :concat-ds (-> (concat-mye-snpp mye-ds
+                                     snpp-ds
+                                     options)
+                    (#(tc/order-by % (tc/column-names %))))})
   ;;=> {:mye-ds [myebtablesenglandwales/myebtablesenglandwales20112024.xlsx]MYEB1: long by LAD (persons) [5 9]:
   ;;   
   ;;   |  :lad23cd |   :lad23nm | :ctyua23cd | :ctyua23nm | :country | :year | :age |    :sex | :population |
@@ -164,7 +167,8 @@
        :max-age   10
        :min-year  2020
        :max-year  2025}
-      ->dataset-by-lad)
+      ->dataset-by-lad
+      (#(tc/order-by % (tc/column-names %))))
   ;;=> [myebtablesenglandwales/myebtablesenglandwales20112024.xlsx]MYEB1: long by LAD (persons) and 2022snpppopulationsyoa/2022snpppopulationsyoamigcat23/2022 SNPP Population persons.csv: long by LAD concatenated at min-snpp-year of 2022 [66 8]:
   ;;   
   ;;   |  :lad23cd |        :lad23nm | :ctyua23cd | :ctyua23nm | :year | :age |    :sex | :population |

--- a/src/witan/population/england.clj
+++ b/src/witan/population/england.clj
@@ -138,15 +138,6 @@
   ;;   |  E10000030 |     Surrey |  2025 |   10 | persons |   15211.734 |
   ;;
 
-  (time
-   (-> {;; :ctyuanm-f #{"Surrey"}
-        ;; :min-age   10
-        :max-age   25
-        ;; :min-year  2020
-        :max-year  2025
-        }
-       ->dataset))
-
   :rcf)
 
 (defn ->dataset-by-ctyua

--- a/src/witan/population/england.clj
+++ b/src/witan/population/england.clj
@@ -32,7 +32,6 @@
                (tc/drop-missing [:age])
                (tc/drop-columns [:age-group :component])
                (tc/select-rows #(-> % :year (>= min-snpp-year))))))
-        (as-> $ (tc/order-by $ (tc/column-names $)))
         (tc/set-dataset-name (format "%s and %s concatenated at min-snpp-year of %d"
                                      (tc/dataset-name mye-ds)
                                      (tc/dataset-name snpp-ds)
@@ -113,9 +112,11 @@
                         (-> options
                             (merge {:max-year (dec min-snpp-year)})
                             mye-f))]
-    (concat-mye-snpp mye-ds
-                     snpp-ds
-                     (assoc options :min-snpp-year min-snpp-year))))
+    (-> (concat-mye-snpp mye-ds
+                         snpp-ds
+                         (assoc options :min-snpp-year min-snpp-year))
+        ;; Sort only at the end
+        (tc/order-by [:ctyua23cd :year :age]))))
 
 (comment ;; Example: CTYUA level for Surrey 10 year olds from 2020 to 2025 from default MYE & 2022 based SNPPs with default min-snpp-year
   (-> {:ctyuanm-f #{"Surrey"}
@@ -134,7 +135,16 @@
   ;;   |  E10000030 |     Surrey |  2023 |   10 | persons |   15376.017 |
   ;;   |  E10000030 |     Surrey |  2024 |   10 | persons |   15173.479 |
   ;;   |  E10000030 |     Surrey |  2025 |   10 | persons |   15211.734 |
-  ;;   
+  ;;
+
+  (time
+   (-> {;; :ctyuanm-f #{"Surrey"}
+        ;; :min-age   10
+        :max-age   25
+        ;; :min-year  2020
+        :max-year  2025
+        }
+       ->dataset))
 
   :rcf)
 

--- a/src/witan/population/england/snpp_2022.clj
+++ b/src/witan/population/england/snpp_2022.clj
@@ -262,7 +262,6 @@
                              :age-group :age
                              :component :sex
                              :population])
-      (tc/order-by $ (tc/column-names $))
       (tc/set-dataset-name $ (str (tc/dataset-name ds) ": long by LAD")))))
 
 (defn ->dataset-by-lad
@@ -305,7 +304,6 @@
                                               #"^:(lad\d\dcd|lad\d\dnm|population)$"))))
      {:population (dsr/sum :population)}
      $)
-    (tc/order-by $ (tc/column-names $))
     (tc/set-dataset-name $ (str/replace (tc/dataset-name ds) "LAD" "CTYUA"))))
 
 (defn ->dataset-by-ctyua

--- a/src/witan/population/england_wales/mye.clj
+++ b/src/witan/population/england_wales/mye.clj
@@ -161,7 +161,6 @@
                              :age
                              :sex
                              :population])
-      (tc/order-by $ (tc/column-names $))
       (tc/set-dataset-name $ (str (tc/dataset-name ds) ": long by LAD (persons)")))))
 
 (defn ->dataset-by-lad
@@ -204,7 +203,6 @@
                                               #"^:(lad\d\dcd|lad\d\dnm|population)$"))))
      {:population (dsr/sum :population)}
      $)
-    (tc/order-by $ (tc/column-names $))
     (tc/set-dataset-name $ (str/replace (tc/dataset-name ds) "LAD" "CTYUA"))))
 
 (defn ->dataset-by-ctyua

--- a/src/witan/send/population/england.clj
+++ b/src/witan/send/population/england.clj
@@ -87,8 +87,9 @@
                            :min-academic-year 7
                            :max-academic-year 7}
                           (ons-pop-ds->witan-send-pop-ds pop-ds))]
-    {:pop-ds       pop-ds
-     :witan-pop-ds witan-pop-ds})
+    (-> {:pop-ds       pop-ds
+         :witan-pop-ds witan-pop-ds}
+        (update-vals #(tc/order-by % (tc/column-names %)))))
   ;;=> {:pop-ds
   ;;    [myebtablesenglandwales/myebtablesenglandwales20112024.xlsx]MYEB1: long by CTYUA (persons) and 2022snpppopulationsyoa/2022snpppopulationsyoamigcat23/2022 SNPP Population persons.csv: long by CTYUA concatenated at min-snpp-year of 2022 [24 6]:
   ;;   
@@ -155,11 +156,13 @@
 (comment ;; Examples using `->dataset`
   ;; Surrey NCY 7 for `calendar-year`s 2021 to 2028 using default ONS population 
   ;; function (with default SNPPs & MYEs)
-  (->dataset {:ctyuanm-f              #{"Surrey"}
-              :min-academic-year      7
-              :max-academic-year      7
-              :min-calendar-year      2021
-              :max-calendar-year      2028})
+  (-> {:ctyuanm-f              #{"Surrey"}
+       :min-academic-year      7
+       :max-academic-year      7
+       :min-calendar-year      2021
+       :max-calendar-year      2028}
+      ->dataset
+      (#(tc/order-by % (tc/column-names %))))
   ;;=> witan.population from [myebtablesenglandwales/myebtablesenglandwales20112024.xlsx]MYEB1: long by CTYUA (persons) and 2022snpppopulationsyoa/2022snpppopulationsyoamigcat23/2022 SNPP Population persons.csv: long by CTYUA concatenated at min-snpp-year of 2022 [8 8]:
   ;;   
   ;;   | :ctyua23cd | :ctyua23nm | :year | :calendar-year | :age | :academic-year |    :sex | :population |
@@ -173,15 +176,17 @@
   ;;   |  E10000030 |     Surrey |  2026 |           2027 |   11 |              7 | persons |   15297.229 |
   ;;   |  E10000030 |     Surrey |  2027 |           2028 |   11 |              7 | persons |   15378.453 |
   ;;   
-
+  
   ;; Surrey NCY 7 for `calendar-year`s 2021 to 2028 using default ONS population 
   ;; function (with default SNPPs & MYEs) using MYEs up to `:calendar-year` 2025
-  (->dataset {:ctyuanm-f              #{"Surrey"}
-              :min-academic-year      7
-              :max-academic-year      7
-              :min-calendar-year      2021
-              :min-snpp-calendar-year 2026
-              :max-calendar-year      2028})
+  (-> {:ctyuanm-f              #{"Surrey"}
+       :min-academic-year      7
+       :max-academic-year      7
+       :min-calendar-year      2021
+       :min-snpp-calendar-year 2026
+       :max-calendar-year      2028}
+      ->dataset
+      (#(tc/order-by % (tc/column-names %))))
   ;;=> witan.population from [myebtablesenglandwales/myebtablesenglandwales20112024.xlsx]MYEB1: long by CTYUA (persons) and 2022snpppopulationsyoa/2022snpppopulationsyoamigcat23/2022 SNPP Population persons.csv: long by CTYUA concatenated at min-snpp-year of 2025 [8 8]:
   ;;   
   ;;   | :ctyua23cd | :ctyua23nm | :year | :calendar-year | :age | :academic-year |    :sex | :population |


### PR DESCRIPTION
From 23 seconds to 1.1 seconds on my machine. ->dataset gets new ordering.